### PR TITLE
fix build issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,20 @@
 include Make.conf
 
 CC	= gcc 
-CFLAGS  = -O2 -Wall -D_GNU_SOURCE -I/usr/local/include -L/usr/local/lib
+#CC	= clang
+
+LOCALBASE	?= /usr/local
+
+PNG_CFLAGS	!= $(LOCALBASE)/bin/libpng15-config --cflags
+PNG_LIBS	!= $(LOCALBASE)/bin/libpng15-config --libs
+
+CFLAGS  = -O2 -Wall -D_GNU_SOURCE $(PNG_CFLAGS) -I$(LOCALBASE)/include
 
 SOURCES	= main.c jpeg.c gif.c png.c bmp.c fb_display.c transforms.c
 OBJECTS	= ${SOURCES:.c=.o}
 
 OUT	= fbv
-LIBS	= -lgif -L/usr/X11R6/lib -ljpeg -lpng
+LIBS	= -L$(LOCALBASE)/lib -lgif -ljpeg $(PNG_LIBS)
 
 all: $(OUT)
 	@echo Build DONE.

--- a/png.c
+++ b/png.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #ifdef FBV_SUPPORT_PNG
 #include <png.h>
+#include <pngstruct.h>
 #include "fbv.h"
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -69,7 +70,7 @@ int fh_png_load(char *name,unsigned char *buffer, unsigned char ** alpha,int x,i
         fclose(fh); return(FH_ERROR_FORMAT);
     }
     rp=0;
-    if (setjmp(png_ptr->jmpbuf))
+    if (setjmp(png_ptr->longjmp_buffer))
     {
 	png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
         if(rp) free(rp);
@@ -161,7 +162,7 @@ int fh_png_getsize(char *name,int *x,int *y)
         fclose(fh); return(FH_ERROR_FORMAT);
     }
     rp=0;
-    if (setjmp(png_ptr->jmpbuf))
+    if (setjmp(png_ptr->longjmp_buffer))
     {
 	png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
         if(rp) free(rp);


### PR DESCRIPTION
手元の環境でビルドする時に行った修正です。
### png.c
- libpng-1.5.17でビルドできるように修正
### Makefile
- libpng用のCFALGS/LIBSをlibpng15-configで取得する
- -L の位置を調整
- ports化しやすいようにLOCALBASEを使う
